### PR TITLE
Build fixes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,7 +53,7 @@ repositories {
 
 dependencies {
     compile  'org.slf4j:slf4j-api:1.7.21'
-    provided 'org.omegat:omegat:4.0.0-02'
+    provided 'org.omegat:omegat:4.0.1'
     provided 'commons-io:commons-io:2.4'
     provided 'commons-lang:commons-lang:2.6'
     provided 'org.slf4j:slf4j-nop:1.5.10'

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-pluginMainClass='org.omegat.filters2.text.dokuwiki.DokuWikiFilter'
+pluginMainClass=org.omegat.filters2.text.dokuwiki.DokuWikiFilter


### PR DESCRIPTION
OmegaT can't load a plugin if main class name contains quotes.
