### PR TITLE
Drop ascii doc example

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,18 +6,6 @@ apply plugin: 'distribution'
 apply plugin: 'maven'
 apply plugin: 'groovy'
 apply plugin: 'idea'
-apply plugin: 'org.asciidoctor.gradle.asciidoctor'
-
-buildscript {
-    repositories {
-        jcenter()
-    }
-    dependencies {
-        classpath 'org.asciidoctor:asciidoctor-gradle-plugin:1.5.3'
-        classpath 'org.asciidoctor:asciidoctorj-diagram:1.3.1'
-        classpath 'org.asciidoctor:asciidoctorj-pdf:1.5.0-alpha.11'
-    }
-}
 
 version = '0.1'
 
@@ -106,35 +94,10 @@ javadoc {
     options.locale = 'en_US'
 }
 
-groovydoc {
-    classpath += configurations.provided
-}
-
 task javadocJar(type: Jar, dependsOn: javadoc) {
     classifier = 'javadoc'
     from javadoc.destinationDir
 }
-
-asciidoctorj {
-    version = '1.5.4.1'
-}
-
-asciidoctor {
-    backends = ['html5', 'pdf']
-    attributes (
-        'build-gradle': file('build.gradle'),
-        'endpoint-url': 'http://omegat.org',
-        'source-highlighter': 'coderay',
-        'imagesdir' : "$rootDir/docs/images",
-        'toc': 'left',
-        'icons': 'font',
-        'setanchors': '',
-        'idprefix': '',
-        'idseparator': '-',
-        'docinfo1': ''
-    )
-}
-tasks.asciidoctor.setGroup('Documentation')
 
 artifacts {
     archives jar
@@ -162,4 +125,3 @@ distributions {
         }
     }
 }
-


### PR DESCRIPTION
THere is no asciidoc example documentation, but
exist configuration.

Signed-off-by: Hiroshi Miura <miurahr@linux.com>